### PR TITLE
Navbar fixes for ARTI-100

### DIFF
--- a/client/assets/styles.css
+++ b/client/assets/styles.css
@@ -373,6 +373,10 @@ ul {
   border-bottom-color: var(--bs-info-bg-subtle);
 }
 
+.nav-link:hover {
+  border-bottom-color: var(--bs-blue);
+}
+
 .navbar-nav > li.login {
     position: static;
 }

--- a/client/assets/styles.css
+++ b/client/assets/styles.css
@@ -369,6 +369,10 @@ ul {
   border-bottom-color: var(--bs-gray-600);
 }
 
+.nav-link.subActive {
+  border-bottom-color: var(--bs-info-bg-subtle);
+}
+
 .navbar-nav > li.login {
     position: static;
 }

--- a/client/components/nav.js
+++ b/client/components/nav.js
@@ -47,7 +47,7 @@ export default function Nav(props) {
                               <div class="col">
                                 <${A}
                                   href=${child.rawPath || [route.path, child.path].join("/")}
-                                  activeClass="active"
+                                  activeClass="subActive"
                                   end=${true}
                                   target=${child.rawPath && "_self" }
                                   class="fs-5 fw-semibold nav-link text-decoration-none me-3 my-3 d-inline-block"
@@ -69,7 +69,7 @@ export default function Nav(props) {
         </div>
       </div>
     </nav>
-    <nav ref=${e => setMenuRef(e)} class="bg-primary text-light position-absolute w-100 z-3 shadow" />
+    <nav ref=${e => setMenuRef(e)} class="bg-info text-light position-absolute w-100 z-3 shadow" />
 
   `;
 }

--- a/client/components/nav.js
+++ b/client/components/nav.js
@@ -1,6 +1,6 @@
 import html from "solid-js/html";
 import { A } from "@solidjs/router";
-import { createSignal, createResource, For, Show } from "solid-js";
+import { createSignal, createResource, createEffect, For, Show } from "solid-js";
 import { Portal } from "solid-js/web";
 
 export default function Nav(props) {
@@ -8,6 +8,27 @@ export default function Nav(props) {
   const [menuRef, setMenuRef] = createSignal(null);
   const [visible, setVisible] = createSignal({});
   const toggleVisible = (key) => setVisible((prev) => ({ [key]: !prev?.[key] }));
+
+  createEffect(() => {
+    const handleClickOutside = (event) => {
+      const isAnyDropdownVisible = Object.keys(visible()).some(
+        key => visible()[key]
+      );
+      const clickedOnPrimaryDropdownToggle = event.target.closest('li.nav-item > a.nav-link.dropdown-toggle');
+      const clickedInMenu = menuRef() && menuRef().contains(event.target);
+      
+      if (!isAnyDropdownVisible || clickedOnPrimaryDropdownToggle || clickedInMenu) {
+        return;
+      }
+      setVisible(prev => ({}));
+    };
+    
+    document.addEventListener("click", handleClickOutside, true);
+    return () => {
+      document.removeEventListener("click", handleClickOutside, true);
+    };
+  });
+
   return html`
     <nav class="navbar navbar-expand-lg font-title">
       <div class="container">

--- a/client/pages/routes.js
+++ b/client/pages/routes.js
@@ -89,7 +89,7 @@ const routes = [
       },
       {
         path: "usage",
-        title: "User Usage",
+        title: "AI Usage Dashboard",
         component: Usage,
         hidden: !hasRole([1]),
       },

--- a/client/pages/users/usage.js
+++ b/client/pages/users/usage.js
@@ -211,7 +211,7 @@ function UsersList() {
   return html`
     <div class="container py-4">
       <div class="d-flex justify-content-between align-items-center mb-3">
-        <h1 class="font-title fs-1 fw-bold mt-4 table-header-color">Usage</h1>
+        <h1 class="font-title fs-1 fw-bold mt-4 table-header-color">AI Usage Dashboard</h1>
       </div>
       
       <!-- Error Alert -->


### PR DESCRIPTION
[ARTI-100](https://tracker.nci.nih.gov/browse/ARTI-100)

- Change the underline color for active/selected menu items 
- Add a hover effect that underlines the menu item in a different shade of blue—for both the main navigation and user menu.
- When the blue user menu bar is open, allow it to close when the user clicks anywhere outside the menu. 
- Rename "User Usage" to "AI Usage Dashboard" - for both menu name and page title.