### PR TITLE
Update edit page

### DIFF
--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -97,6 +97,19 @@ function UserEdit() {
   function handleRoleChange(roleId) {
     // Simply update the role ID without changing limit settings
     setUser((prev) => ({ ...prev, roleId }));
+    if (roleId === 1) {
+      setUser((prev) => ({
+        ...prev,
+        noLimit: true,
+        limit: null,
+      }));
+    } else {
+      setUser((prev) => ({
+        ...prev,
+        noLimit: false,
+        limit: prev.limit === null ? originalUser().limit || 5 : prev.limit,
+      }));
+    }
   }
 
   function handleInputChange(field, value) {

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -335,7 +335,7 @@ function UserEdit() {
                 <//>
               </div>
               <div class="small text-muted">
-                Remaining: $${() => (user().remaining !== null ? parseFloat(user().remaining).toFixed(2) : "N/A")}
+                Remaining: $${() => (user().noLimit ? 0 : user().remaining !== null ? parseFloat(user().remaining).toFixed(2) : "N/A")}
               </div>
             </div>
           </div>

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -341,7 +341,10 @@ function UserEdit() {
                 <//>
               </div>
               <div class="small text-muted">
-                Remaining: $${() => (!user().noLimit && user().remaining !== null ? parseFloat(user().remaining).toFixed(2) : "N/A")}
+                Remaining: $${() =>
+                  !user().noLimit && user().remaining !== null
+                    ? Math.max(0, parseFloat(user().remaining)).toFixed(2)
+                    : "N/A"}
               </div>
             </div>
           </div>

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -346,7 +346,7 @@ function UserEdit() {
             <div class="col-12 mt-4">
               <div class="d-flex gap-2 justify-content-center">
                 <a href="/_/users" class="btn btn-outline-secondary text-decoration-none"> Cancel </a>
-                <button type="submit" class="btn btn-primary" disabled=${saving}>${() => (saving() ? "Saving..." : "Save User")}</button>
+                <button type="submit" class="btn btn-primary" disabled=${saving}>${() => (saving() ? "Saving..." : "Save")}</button>
               </div>
             </div>
           </div>

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -110,6 +110,19 @@ function UserEdit() {
     }));
   }
 
+  // Format limit to two decimal places on blur to ensure consistent formatting
+  function handleLimitBlur() {
+    const currentValue = user().limit;
+    const num = parseFloat(currentValue);
+
+    if (!isNaN(num)) {
+      const formattedValue = num.toFixed(2);
+      handleInputChange("limit", formattedValue);
+    } else {
+      handleInputChange("limit", "");
+    }
+  }
+
   function copyToClipboard(text) {
     navigator.clipboard
       .writeText(text)
@@ -324,15 +337,16 @@ function UserEdit() {
               <div class="input-group mb-2">
                 <span class="input-group-text">$</span>
                 <input
-                  type="number"
-                  step="0.01"
-                  min="0"
+                  type="text"
+                  inputmode="decimal" 
                   class="form-control"
                   disabled=${() => user().noLimit}
                   id="limit"
-                  value=${() => user().limit || 0}
-                  onInput=${(e) => handleInputChange("limit", parseFloat(e.target.value) || 0)}
-                  aria-label="Weekly cost limit" />
+                  value=${() => user().limit ?? ""}
+                  onInput=${(e) => handleInputChange("limit", e.target.value)}
+                  onBlur=${handleLimitBlur}
+                  aria-label="Weekly cost limit"
+                />
                 <${Show} when=${() => params.id}>
                   <button 
                     type="button" 

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -37,6 +37,7 @@ function UserEdit() {
       .then((data) => {
         // Set noLimit flag based on limit being null
         data.noLimit = data.limit === null;
+        data.limit = formatLimitForDisplay(data.limit);
         setUser(data);
         setOriginalUser(data);
         return data;
@@ -110,17 +111,18 @@ function UserEdit() {
     }));
   }
 
+  function formatLimitForDisplay(value) {
+    const num = parseFloat(value);
+    if (!isNaN(num)) {
+      return num.toFixed(2);
+    }
+    return 0.00.toFixed(2);
+  }
+
   // Format limit to two decimal places on blur to ensure consistent formatting
   function handleLimitBlur() {
-    const currentValue = user().limit;
-    const num = parseFloat(currentValue);
-
-    if (!isNaN(num)) {
-      const formattedValue = num.toFixed(2);
-      handleInputChange("limit", formattedValue);
-    } else {
-      handleInputChange("limit", "");
-    }
+    const formattedValue = formatLimitForDisplay(user().limit);
+    handleInputChange("limit", formattedValue);
   }
 
   function copyToClipboard(text) {

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -37,9 +37,9 @@ function UserEdit() {
       .then((data) => {
         // Set noLimit flag based on limit being null
         data.noLimit = data.limit === null;
-        data.limit = formatLimitForDisplay(data.limit);
-        setUser(data);
         setOriginalUser(data);
+        data.limit = data.limit !== null ? formatLimitForDisplay(data.limit) : data.limit;
+        setUser(data);
         return data;
       });
   });
@@ -50,15 +50,15 @@ function UserEdit() {
 
     try {
       const userData = { ...user() };
-
+      userData.limit = parseFloat(userData.limit);
       // Handle no limit case - send null for limit when noLimit is true
       if (userData.noLimit) {
         userData.limit = null;
       }
       // Track differences in limit to adjust remaining accordingly even if limit becomes null
-      if (originalUser().limit !== userData.limit) {
-        const limitDiff = (userData.limit || 0) - (originalUser().limit || 0);
-        userData.remaining = (userData.remaining || 0) + limitDiff;
+      if (parseFloat(originalUser().limit) !== userData.limit) {
+        const limitDiff = (userData.limit || 0) - (parseFloat(originalUser().limit) || 0);
+        userData.remaining = (parseFloat(userData.remaining) || 0) + limitDiff;
       }
 
       // Include generateApiKey flag if checked
@@ -82,8 +82,9 @@ function UserEdit() {
         const data = await response.json();
         throw new Error(data.error || "Failed to save user");
       }
-      setUser(userData);
       setOriginalUser(userData);
+      userData.limit = userData.limit !== null ? formatLimitForDisplay(userData.limit) : userData.limit;
+      setUser(userData);
       setShowSuccess(true);
       setTimeout(() => setShowSuccess(false), 3000);
     } catch (err) {
@@ -107,7 +108,7 @@ function UserEdit() {
       setUser((prev) => ({
         ...prev,
         noLimit: false,
-        limit: prev.limit === null ? originalUser().limit || 5 : prev.limit,
+        limit: prev.limit === null ? formatLimitForDisplay(originalUser().limit || 5) : prev.limit,
       }));
     }
   }
@@ -120,7 +121,7 @@ function UserEdit() {
     setUser((prev) => ({
       ...prev,
       noLimit: checked,
-      limit: checked ? null : originalUser().limit || 5,
+      limit: checked ? null : formatLimitForDisplay(originalUser().limit || 5),
     }));
   }
 

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -24,6 +24,7 @@ function UserEdit() {
   const [showResetMessage, setShowResetMessage] = createSignal(false);
 
   const ADMIN_ROLE_ID = 1;
+  const DEFAULT_WEEKLY_LIMIT = 5.00;
 
   // Fetch roles data using resource
   const [roles] = createResource(() => fetch("/api/admin/roles").then((res) => res.json()));
@@ -110,7 +111,7 @@ function UserEdit() {
       setUser((prev) => ({
         ...prev,
         noLimit: false,
-        limit: prev.limit === null ? formatLimitForDisplay(originalUser().limit || 5) : prev.limit,
+        limit: prev.limit === null ? formatLimitForDisplay(originalUser().limit || DEFAULT_WEEKLY_LIMIT) : prev.limit,
       }));
     }
   }
@@ -123,7 +124,7 @@ function UserEdit() {
     setUser((prev) => ({
       ...prev,
       noLimit: checked,
-      limit: checked ? null : formatLimitForDisplay(originalUser().limit || 5),
+      limit: checked ? null : formatLimitForDisplay(originalUser().limit || DEFAULT_WEEKLY_LIMIT),
     }));
   }
 

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -23,6 +23,8 @@ function UserEdit() {
   const [resetMessage, setResetMessage] = createSignal("");
   const [showResetMessage, setShowResetMessage] = createSignal(false);
 
+  const ADMIN_ROLE_ID = 1;
+
   // Fetch roles data using resource
   const [roles] = createResource(() => fetch("/api/admin/roles").then((res) => res.json()));
 
@@ -98,7 +100,7 @@ function UserEdit() {
   function handleRoleChange(roleId) {
     // Simply update the role ID without changing limit settings
     setUser((prev) => ({ ...prev, roleId }));
-    if (roleId === 1) {
+    if (roleId === ADMIN_ROLE_ID) {
       setUser((prev) => ({
         ...prev,
         noLimit: true,

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -50,9 +50,6 @@ function UserEdit() {
     try {
       const userData = { ...user() };
 
-      // Include ID for user being edited
-      userData.id = params.id;
-
       // Handle no limit case - send null for limit when noLimit is true
       if (userData.noLimit) {
         userData.limit = null;
@@ -61,25 +58,31 @@ function UserEdit() {
       if (originalUser().limit !== userData.limit) {
         const limitDiff = (userData.limit || 0) - (originalUser().limit || 0);
         userData.remaining = (userData.remaining || 0) + limitDiff;
-        //for when remaining is negative, we still store it but set it to 0 in the UI
       }
-      delete userData.noLimit; // Remove the UI-only property
 
       // Include generateApiKey flag if checked
       if (generateApiKey()) {
         userData.generateApiKey = true;
       }
 
+      const apiPayload = { ...userData };
+      // Include ID for user being edited
+      apiPayload.id = params.id;
+      // Remove the UI-only property
+      delete apiPayload.noLimit; 
+
       const response = await fetch("/api/admin/users", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(userData),
+        body: JSON.stringify(apiPayload),
       });
 
       if (!response.ok) {
         const data = await response.json();
         throw new Error(data.error || "Failed to save user");
       }
+      setUser(userData);
+      setOriginalUser(userData);
     } catch (err) {
       console.error("Error saving user:", err);
       alert(err.message || "An error occurred while saving the user");

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -97,7 +97,7 @@ function UserEdit() {
     setUser((prev) => ({
       ...prev,
       noLimit: checked,
-      limit: checked ? null : prev.limit || 5,
+      limit: checked ? null : originalUser().limit || 5,
     }));
   }
 

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -335,7 +335,7 @@ function UserEdit() {
                 <//>
               </div>
               <div class="small text-muted">
-                Remaining: $${() => (user().noLimit ? 0 : user().remaining !== null ? parseFloat(user().remaining).toFixed(2) : "N/A")}
+                Remaining: $${() => (!user().noLimit && user().remaining !== null ? parseFloat(user().remaining).toFixed(2) : "N/A")}
               </div>
             </div>
           </div>

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -57,6 +57,12 @@ function UserEdit() {
       if (userData.noLimit) {
         userData.limit = null;
       }
+      // Track differences in limit to adjust remaining accordingly even if limit becomes null
+      if (originalUser().limit !== userData.limit) {
+        const limitDiff = (userData.limit || 0) - (originalUser().limit || 0);
+        userData.remaining = (userData.remaining || 0) + limitDiff;
+        //for when remaining is negative, we still store it but set it to 0 in the UI
+      }
       delete userData.noLimit; // Remove the UI-only property
 
       // Include generateApiKey flag if checked

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -319,6 +319,7 @@ function UserEdit() {
                   step="0.01"
                   min="0"
                   class="form-control"
+                  disabled=${() => user().noLimit}
                   id="limit"
                   value=${() => user().limit || 0}
                   onInput=${(e) => handleInputChange("limit", parseFloat(e.target.value) || 0)}
@@ -326,6 +327,7 @@ function UserEdit() {
                 <${Show} when=${() => params.id}>
                   <button 
                     type="button" 
+                    disabled=${() => user().noLimit}
                     class="btn btn-outline-primary"
                     onClick=${resetUserLimit}>
                     Reset

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -312,31 +312,29 @@ function UserEdit() {
                 <label class="form-check-label" for="noLimitCheckbox">Unlimited</label>
               </div>
 
-              <${Show} when=${() => !user().noLimit}>
-                <div class="input-group mb-2">
-                  <span class="input-group-text">$</span>
-                  <input
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    class="form-control"
-                    id="limit"
-                    value=${() => user().limit || 0}
-                    onInput=${(e) => handleInputChange("limit", parseFloat(e.target.value) || 0)}
-                    aria-label="Weekly cost limit" />
-                  <${Show} when=${() => params.id}>
-                    <button 
-                      type="button" 
-                      class="btn btn-outline-primary"
-                      onClick=${resetUserLimit}>
-                      Reset
-                    </button>
-                  <//>
-                </div>
-                <div class="small text-muted">
-                  Remaining: $${() => (user().remaining !== null ? parseFloat(user().remaining).toFixed(2) : "N/A")}
-                </div>
-              <//>
+              <div class="input-group mb-2">
+                <span class="input-group-text">$</span>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  class="form-control"
+                  id="limit"
+                  value=${() => user().limit || 0}
+                  onInput=${(e) => handleInputChange("limit", parseFloat(e.target.value) || 0)}
+                  aria-label="Weekly cost limit" />
+                <${Show} when=${() => params.id}>
+                  <button 
+                    type="button" 
+                    class="btn btn-outline-primary"
+                    onClick=${resetUserLimit}>
+                    Reset
+                  </button>
+                <//>
+              </div>
+              <div class="small text-muted">
+                Remaining: $${() => (user().remaining !== null ? parseFloat(user().remaining).toFixed(2) : "N/A")}
+              </div>
             </div>
           </div>
 

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -83,13 +83,13 @@ function UserEdit() {
       }
       setUser(userData);
       setOriginalUser(userData);
+      setShowSuccess(true);
+      setTimeout(() => setShowSuccess(false), 3000);
     } catch (err) {
       console.error("Error saving user:", err);
       alert(err.message || "An error occurred while saving the user");
     } finally {
       setSaving(false);
-      setShowSuccess(true);
-      setTimeout(() => setShowSuccess(false), 3000);
     }
   }
 


### PR DESCRIPTION
[ARTI-96](https://tracker.nci.nih.gov/browse/ARTI-96) 
- limit field shows even with unlimited toggled on
- limit fields are visible but disabled when unlimited is toggled on
- set remaining to N/A when unlimited is toggled on (only in display)
- limit always defaults back to original value 
- remaining will go up and down with limit (even going negative to keep track but display will always be nonnegative)
- After successful post, the UI (remaining) updates to reflect new values
- moved improperly placed statements to after success (not finally block)
- removed input type=number in order to add support for typing decimals
- can no longer increment by .01 in input field
- limit will always be formatted with a trailing two decimal fields
- roleChanges between admin and nonAdmin automatically toggles noLimit to active and not active respectively