### PR TITLE
Simplify edit page

### DIFF
--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -340,7 +340,7 @@ function UserEdit() {
                 <//>
               </div>
               <div class="small text-muted">
-                Remaining: $${() => (user().remaining !== null ? parseFloat(user().remaining).toFixed(2) : "N/A")}
+                Remaining: $${() => (!user().noLimit && user().remaining !== null ? parseFloat(user().remaining).toFixed(2) : "N/A")}
               </div>
             </div>
           </div>

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -16,7 +16,6 @@ function UserEdit() {
     remaining: 0,
     noLimit: false,
   });
-  const [originalUser, setOriginalUser] = createSignal({ ...user() });
   const [generateApiKey, setGenerateApiKey] = createSignal(false);
   const [saving, setSaving] = createSignal(false);
   const [showSuccess, setShowSuccess] = createSignal(false);
@@ -38,7 +37,6 @@ function UserEdit() {
         // Set noLimit flag based on limit being null
         data.noLimit = data.limit === null;
         setUser(data);
-        setOriginalUser(data);
         return data;
       });
   });

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -351,7 +351,7 @@ function UserEdit() {
             <div class="col-12 mt-4">
               <div class="d-flex gap-2 justify-content-center">
                 <a href="/_/users" class="btn btn-outline-secondary text-decoration-none"> Cancel </a>
-                <button type="submit" class="btn btn-primary" disabled=${saving}>${() => (saving() ? "Saving..." : "Save User")}</button>
+                <button type="submit" class="btn btn-primary" disabled=${saving}>${() => (saving() ? "Saving..." : "Save")}</button>
               </div>
             </div>
           </div>

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -324,6 +324,7 @@ function UserEdit() {
                   step="0.01"
                   min="0"
                   class="form-control"
+                  disabled=${() => user().noLimit}
                   id="limit"
                   value=${() => user().limit || 0}
                   onInput=${(e) => handleInputChange("limit", parseFloat(e.target.value) || 0)}
@@ -331,6 +332,7 @@ function UserEdit() {
                 <${Show} when=${() => params.id}>
                   <button 
                     type="button" 
+                    disabled=${() => user().noLimit}
                     class="btn btn-outline-primary"
                     onClick=${resetUserLimit}>
                     Reset

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -317,31 +317,29 @@ function UserEdit() {
                 <label class="form-check-label" for="noLimitCheckbox">Unlimited</label>
               </div>
 
-              <${Show} when=${() => !user().noLimit}>
-                <div class="input-group mb-2">
-                  <span class="input-group-text">$</span>
-                  <input
-                    type="number"
-                    step="0.01"
-                    min="0"
-                    class="form-control"
-                    id="limit"
-                    value=${() => user().limit || 0}
-                    onInput=${(e) => handleInputChange("limit", parseFloat(e.target.value) || 0)}
-                    aria-label="Weekly cost limit" />
-                  <${Show} when=${() => params.id}>
-                    <button 
-                      type="button" 
-                      class="btn btn-outline-primary"
-                      onClick=${resetUserLimit}>
-                      Reset
-                    </button>
-                  <//>
-                </div>
-                <div class="small text-muted">
-                  Remaining: $${() => (user().remaining !== null ? parseFloat(user().remaining).toFixed(2) : "N/A")}
-                </div>
-              <//>
+              <div class="input-group mb-2">
+                <span class="input-group-text">$</span>
+                <input
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  class="form-control"
+                  id="limit"
+                  value=${() => user().limit || 0}
+                  onInput=${(e) => handleInputChange("limit", parseFloat(e.target.value) || 0)}
+                  aria-label="Weekly cost limit" />
+                <${Show} when=${() => params.id}>
+                  <button 
+                    type="button" 
+                    class="btn btn-outline-primary"
+                    onClick=${resetUserLimit}>
+                    Reset
+                  </button>
+                <//>
+              </div>
+              <div class="small text-muted">
+                Remaining: $${() => (user().remaining !== null ? parseFloat(user().remaining).toFixed(2) : "N/A")}
+              </div>
             </div>
           </div>
 

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -102,7 +102,7 @@ function UserEdit() {
     setUser((prev) => ({
       ...prev,
       noLimit: checked,
-      limit: checked ? null : prev.limit || 5,
+      limit: checked ? null : DEFAULT_ROLE_LIMITS[prev.roleId]?.limit || 0,
     }));
   }
 

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -16,6 +16,7 @@ function UserEdit() {
     remaining: 0,
     noLimit: false,
   });
+  const [originalLimit, setOriginalLimit] = createSignal(0);
   const [generateApiKey, setGenerateApiKey] = createSignal(false);
   const [saving, setSaving] = createSignal(false);
   const [showSuccess, setShowSuccess] = createSignal(false);
@@ -44,6 +45,7 @@ function UserEdit() {
         // Set noLimit flag based on limit being null
         data.noLimit = data.limit === null;
         setUser(data);
+        setOriginalLimit(data.limit || 0);
         return data;
       });
   });
@@ -64,6 +66,10 @@ function UserEdit() {
       }
       delete userData.noLimit; // Remove the UI-only property
 
+      if (userData.limit !== originalLimit()) {
+        userData.remaining = userData.limit; // Reset remaining to if limit changes
+      }
+
       // Include generateApiKey flag if checked
       if (generateApiKey()) {
         userData.generateApiKey = true;
@@ -81,6 +87,8 @@ function UserEdit() {
       }
       setShowSuccess(true);
       setTimeout(() => setShowSuccess(false), 3000);
+      setUser((prev) => ({ ...prev, remaining: userData.remaining })); // Update remaining on UI
+      setOriginalLimit(userData.limit || 0); // Reset original limit to new value
     } catch (err) {
       console.error("Error saving user:", err);
       alert(err.message || "An error occurred while saving the user");

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -79,13 +79,13 @@ function UserEdit() {
         const data = await response.json();
         throw new Error(data.error || "Failed to save user");
       }
+      setShowSuccess(true);
+      setTimeout(() => setShowSuccess(false), 3000);
     } catch (err) {
       console.error("Error saving user:", err);
       alert(err.message || "An error occurred while saving the user");
     } finally {
       setSaving(false);
-      setShowSuccess(true);
-      setTimeout(() => setShowSuccess(false), 3000);
     }
   }
 

--- a/client/pages/users/edit.js
+++ b/client/pages/users/edit.js
@@ -22,6 +22,13 @@ function UserEdit() {
   const [resetMessage, setResetMessage] = createSignal("");
   const [showResetMessage, setShowResetMessage] = createSignal(false);
 
+  // Default value mapping based on role ID
+  const DEFAULT_ROLE_LIMITS = {
+    1: { limit: null, remaining: 0, noLimit: true }, // Admin
+    2: { limit: 10, remaining: 10, noLimit: false }, // Super Admin
+    3: { limit: 5, remaining: 5, noLimit: false }, // User
+  };
+
   // Fetch roles data using resource
   const [roles] = createResource(() => fetch("/api/admin/roles").then((res) => res.json()));
 
@@ -84,7 +91,7 @@ function UserEdit() {
 
   function handleRoleChange(roleId) {
     // Simply update the role ID without changing limit settings
-    setUser((prev) => ({ ...prev, roleId }));
+    setUser((prev) => ({ ...prev, roleId, ...DEFAULT_ROLE_LIMITS[roleId] || {} }));
   }
 
   function handleInputChange(field, value) {


### PR DESCRIPTION
[ARTI-96](https://tracker.nci.nih.gov/browse/ARTI-96)
- removed originalUser signal and replaced with originalLimit, used to track if limit changed
- Added default role limits, which display when a role is changed
- The limit field is always shown even with noLimit toggled on
- Changed text from 'save text' to just 'save'
- Changed remaining to NA when noLimit is true
- When toggling the noLimit on and off, the default limit based on role will be used
- Moved success prompt into try block
- Reset remaining if limit is changed