### PR TITLE
Manage users UI improvements

### DIFF
--- a/client/pages/users/index.js
+++ b/client/pages/users/index.js
@@ -26,7 +26,7 @@ function UsersList() {
 
   // Server-side users resource with all parameters
   const usersParams = createMemo(() => ({
-    search: searchQuery(),
+    search: searchQuery().length >= 3 ? searchQuery() : undefined,
     roleId: selectedRole() === "All" ? undefined : rolesResource()?.find(r => r.name === selectedRole())?.id,
     status: selectedStatus() === "All" ? undefined : selectedStatus(),
     sortBy: sortColumn(),
@@ -161,7 +161,7 @@ function UsersList() {
         loadingText="Loading users..."
         totalItems=${() => usersResource()?.meta?.total || 0}
         page=${currentPage}
-        search=${searchQuery}
+        search=${() => searchQuery().length >= 3 ? searchQuery() : ""}
         sortColumn=${sortColumn}
         sortOrder=${sortOrder}
         onSort=${handleSort}

--- a/client/pages/users/index.js
+++ b/client/pages/users/index.js
@@ -187,6 +187,11 @@ function UsersList() {
             cellClassName: "small"
           },
           {
+            key: "role",
+            title: "Role",
+            cellClassName: "text-capitalize small"
+          },
+          {
             key: "status",
             title: "Status",
             render: (user) => html`
@@ -200,11 +205,6 @@ function UsersList() {
                 ${user.status}
               </span>
             `
-          },
-          {
-            key: "role",
-            title: "Role",
-            cellClassName: "text-capitalize small"
           },
           {
             key: "limit",

--- a/client/pages/users/index.js
+++ b/client/pages/users/index.js
@@ -113,6 +113,17 @@ function UsersList() {
         <div class="card-body">
           <div class="row g-3 align-items-end">
             <div class="col-md-3">
+              <label for="search-filter" class="form-label">User</label>
+              <input 
+                type="text" 
+                class="form-control" 
+                id="search-filter"
+                placeholder="Search by name or email"
+                value=${searchQuery}
+                onInput=${e => handleSearch(e.target.value)}
+              />
+            </div>
+            <div class="col-md-3">
               <label for="role-filter" class="form-label">Role</label>
               <select 
                 class="form-select" 
@@ -137,17 +148,6 @@ function UsersList() {
                   ${status => html`<option value=${status}>${capitalize(status)}</option>`}
                 <//>
               </select>
-            </div>
-            <div class="col-md-6">
-              <label for="search-filter" class="form-label">User</label>
-              <input 
-                type="text" 
-                class="form-control" 
-                id="search-filter"
-                placeholder="Search by name or email"
-                value=${searchQuery}
-                onInput=${e => handleSearch(e.target.value)}
-              />
             </div>
           </div>
         </div>

--- a/client/pages/users/index.js
+++ b/client/pages/users/index.js
@@ -11,7 +11,7 @@ function UsersList() {
   // Server-side filters & sorting
   const [searchQuery, setSearchQuery] = createSignal("");
   const [selectedRole, setSelectedRole] = createSignal("All");
-  const [selectedStatus, setSelectedStatus] = createSignal("All");
+  const [selectedStatus, setSelectedStatus] = createSignal("active");
   const [sortColumn, setSortColumn] = createSignal("lastName");
   const [sortOrder, setSortOrder] = createSignal("asc");
   const [currentPage, setCurrentPage] = createSignal(1);
@@ -145,7 +145,7 @@ function UsersList() {
                 aria-label="Select Status Filter"
                 onInput=${e => handleStatusChange(e.target.value)}>
                 <${For} each=${statuses}>
-                  ${status => html`<option value=${status}>${capitalize(status)}</option>`}
+                  ${status => html`<option value=${status} selected=${() => selectedStatus() === status}>${capitalize(status)}</option>`}
                 <//>
               </select>
             </div>

--- a/client/pages/users/index.js
+++ b/client/pages/users/index.js
@@ -111,7 +111,6 @@ function UsersList() {
       <!-- Filters -->
       <div class="card shadow-sm mb-4">
         <div class="card-body">
-          <h5 class="card-title">Filter</h5>
           <div class="row g-3 align-items-end">
             <div class="col-md-3">
               <label for="role-filter" class="form-label">Role</label>

--- a/client/pages/users/index.js
+++ b/client/pages/users/index.js
@@ -145,7 +145,7 @@ function UsersList() {
                 aria-label="Select Status Filter"
                 onInput=${e => handleStatusChange(e.target.value)}>
                 <${For} each=${statuses}>
-                  ${status => html`<option value=${status} selected=${() => selectedStatus() === status}>${capitalize(status)}</option>`}
+                  ${status => html`<option value=${status} selected=${selectedStatus() === status}>${capitalize(status)}</option>`}
                 <//>
               </select>
             </div>

--- a/client/pages/users/index.js
+++ b/client/pages/users/index.js
@@ -139,16 +139,15 @@ function UsersList() {
               </select>
             </div>
             <div class="col-md-6">
-              <div class="input-group">
-                <span class="input-group-text">Search</span>
-                <input 
-                  type="text" 
-                  class="form-control" 
-                  placeholder="Search by name or email"
-                  value=${searchQuery}
-                  onInput=${e => handleSearch(e.target.value)}
-                />
-              </div>
+              <label for="search-filter" class="form-label">User</label>
+              <input 
+                type="text" 
+                class="form-control" 
+                id="search-filter"
+                placeholder="Search by name or email"
+                value=${searchQuery}
+                onInput=${e => handleSearch(e.target.value)}
+              />
             </div>
           </div>
         </div>


### PR DESCRIPTION
Following the spec in [ARTI-116](https://tracker.nci.nih.gov/browse/ARTI-116)
## Filters
- Removed Filter Header under filter section
- Default field for _Status_ is now **Active** instead of **All**. (needed to add selected flag to Select Component to not auto pick the first option)
### Search Filter Changes
- Changed search label to float above to match other filter
- Search label now called 'user'
- User search filter is now moved to the front as the first filter
- User search size reduced to match the other two filters
- User search only triggers if there are 3 or more characters

## Columns
- Role ordered to be before status, matching with the filters